### PR TITLE
Add stop generating button

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -12,6 +12,6 @@
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-06-04T13:51:31.746039Z" />
+    <timeTargetWasSelectedWithDropDown value="2023-06-21T15:54:11.244912Z" />
   </component>
 </project>

--- a/app/src/main/java/com/chatgptlite/wanted/constants/Constants.kt
+++ b/app/src/main/java/com/chatgptlite/wanted/constants/Constants.kt
@@ -9,4 +9,4 @@ const val urlToGithub = "https://github.com/lambiengcode"
 
 const val matchResultString = "\"text\":"
 const val matchResultTurboString = "\"content\":"
-const val ConversationTestTag = "ConversationTestTag"
+const val conversationTestTag = "ConversationTestTag"

--- a/app/src/main/java/com/chatgptlite/wanted/constants/Constants.kt
+++ b/app/src/main/java/com/chatgptlite/wanted/constants/Constants.kt
@@ -9,3 +9,4 @@ const val urlToGithub = "https://github.com/lambiengcode"
 
 const val matchResultString = "\"text\":"
 const val matchResultTurboString = "\"content\":"
+const val ConversationTestTag = "ConversationTestTag"

--- a/app/src/main/java/com/chatgptlite/wanted/ui/conversations/Conversation.kt
+++ b/app/src/main/java/com/chatgptlite/wanted/ui/conversations/Conversation.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.chatgptlite.wanted.constants.ConversationTestTag
+import com.chatgptlite.wanted.constants.conversationTestTag
 import com.chatgptlite.wanted.models.MessageModel
 import com.chatgptlite.wanted.ui.conversations.components.MessageCard
 import com.chatgptlite.wanted.ui.conversations.components.TextInput
@@ -68,7 +68,7 @@ fun MessageList(
             contentPadding =
             WindowInsets.statusBars.add(WindowInsets(top = 90.dp)).asPaddingValues(),
             modifier = Modifier
-                .testTag(ConversationTestTag)
+                .testTag(conversationTestTag)
                 .fillMaxSize(),
             reverseLayout = true,
             state = listState,

--- a/app/src/main/java/com/chatgptlite/wanted/ui/conversations/Conversation.kt
+++ b/app/src/main/java/com/chatgptlite/wanted/ui/conversations/Conversation.kt
@@ -1,17 +1,27 @@
 package com.chatgptlite.wanted.ui.conversations
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.chatgptlite.wanted.constants.ConversationTestTag
 import com.chatgptlite.wanted.models.MessageModel
 import com.chatgptlite.wanted.ui.conversations.components.MessageCard
 import com.chatgptlite.wanted.ui.conversations.components.TextInput
@@ -27,18 +37,17 @@ fun Conversation() {
         ) {
             Box(Modifier.fillMaxSize()) {
                 Column(Modifier.fillMaxSize()) {
-                    MessageList(modifier = Modifier
-                        .weight(1f)
-                        .padding(horizontal = 16.dp))
+                    MessageList(
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(horizontal = 16.dp)
+                    )
                     TextInput()
                 }
             }
         }
     }
 }
-
-
-const val ConversationTestTag = "ConversationTestTag"
 
 @Composable
 fun MessageList(
@@ -49,6 +58,7 @@ fun MessageList(
 
     val conversationId by conversationViewModel.currentConversationState.collectAsState()
     val messagesMap by conversationViewModel.messagesState.collectAsState()
+    val isFabExpanded by conversationViewModel.isFabExpanded.collectAsState()
 
     val messages: List<MessageModel> =
         if (messagesMap[conversationId] == null) listOf() else messagesMap[conversationId]!!
@@ -76,9 +86,31 @@ fun MessageList(
                 }
             }
         }
+        ExtendedFloatingActionButton(
+            text = {
+                Text(text = "Stop Generating", color = Color.White)
+            },
+            icon = {
+                Icon(
+                    imageVector = Icons.Default.Stop,
+                    contentDescription = "Stop Generating",
+                    tint = Color.White,
+                    modifier = Modifier
+                        .size(35.dp)
+                )
+            },
+            onClick = {
+                conversationViewModel.stopReceivingResults()
+            },
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(bottom = 16.dp)
+                .animateContentSize(),
+            expanded = isFabExpanded,
+        )
     }
 }
-
 
 
 @Preview(showBackground = true)


### PR DESCRIPTION
*Added an ExtendedFloatingActionButton (expanded) to stop collection flow from API. When flow collection button expands with text "Stop Generating" then when user stops or collect completes button shows icon only. Cleaned the code by moving conts from conversion compose to Constants.  *

## Pre-launch Checklist

- [x ] I read the rules PR (title, labels, commit messages...).
- [x] I definitely don't PR files with pointless edits.
- [x ] I added screenshots if change UI/UX (has modified code in lib/src/ui/*).
- [- ] I writen all test cases coverage and all passed.
- [x ] All existing and new tests are passing.

## Testcases covered (check if passed)

- [- ] Case 1
- [- ] Case 2
- [- ] Case 3
## Screenshots (if change UI/UX)
![Screenshot_20230621_165633_ChatGPT Lite](https://github.com/lambiengcode/compose-chatgpt-kotlin-android-chatbot/assets/74240451/100caeb8-6915-4785-933f-fc11cf286dcb)

